### PR TITLE
Implements report subscription unsubscribe

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,15 @@ module.exports = {
     }),
   },
 
+  apiServer: {
+    host: entry({
+      key: 'API_SERVER_HOST',
+      doc: 'Protocol, host and port where the server is exposed to clients.',
+      defaults: {development: 'http://localhost:8080', test: 'http://localhost:8080'},
+      required: true,
+    }),
+  },
+
   pubsub: {
     reports: {
       topic: entry({

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,12 +1,25 @@
 const email = require('./services/email');
+const config = require('./config');
 
 const reportResultsMessage = (report) => {
   if (report.empty) {
     return "No vessels were found."
   } else {
     return `
-You can download the report from ${report.uploads.pdf}. The raw data can also be downloaded from ${report.uploads.csv}`;
+You can download the report from ${report.uploads.pdf}. The raw data can also be downloaded from ${report.uploads.csv}.`;
   }
+};
+
+const unsubscribeLink = (request) => {
+  if (!request.recurrency) {
+    return "";
+  }
+
+  const encodedSubscriptionId = new Buffer(JSON.stringify(request.subscriptionId)).toString("base64");
+
+  return `
+You received this email because you subscribed to a ${request.recurrency} report on this area. To stop receiving these emails, navigate to ${config.apiServer.host}/v2/subscriptions/${encodedSubscriptionId}/cancel.
+  `;
 };
 
 const emailBody = (report, request) => {
@@ -17,7 +30,10 @@ You requested a fishing hours report with the following parameters:
   From: ${request.params.from}
   To: ${request.params.to}
 
-${reportResultsMessage(report)}`;
+${reportResultsMessage(report)}
+
+${unsubscribeLink(request)}
+  `;
 };
 
 module.exports = (report, request) => {


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/558.

This PR only implements the unsubscribe link on the email for automatic reports. See https://github.com/GlobalFishingWatch/api-pelagos/pull/196 for the main changes on the API.

